### PR TITLE
Updated detail::CipherTag in hwy/ops/ppc_vsx-inl.h for Clang 16 and later

### DIFF
--- a/hwy/ops/ppc_vsx-inl.h
+++ b/hwy/ops/ppc_vsx-inl.h
@@ -2628,7 +2628,7 @@ HWY_API Mask128<T, N> IsFinite(Vec128<T, N> v) {
 #endif
 
 namespace detail {
-#if HWY_COMPILER_CLANG
+#if HWY_COMPILER_CLANG && HWY_COMPILER_CLANG < 1600
 using CipherTag = Full128<uint64_t>;
 #else
 using CipherTag = Full128<uint8_t>;


### PR DESCRIPTION
There was a recent change to Clang 16 and later that changes the parameter types and return types of the ```vec_cipher_be``` and ```vec_cipherlast_be``` functions to ```__vector unsigned char```.